### PR TITLE
metaタグ切り分け、css読み込み修正

### DIFF
--- a/_shopify_files/edited/layout/theme.liquid
+++ b/_shopify_files/edited/layout/theme.liquid
@@ -7,8 +7,8 @@
 	<link rel="shortcut icon" type="image/x-icon" href="https://journal.komons-japan.com/wp-content/themes/komons-theme/img/icon/icon.jpg">
 	<link rel="apple-touch-icon" href="https://journal.komons-japan.com/wp-content/themes/komons-theme/img/icon/icon.jpg" sizes="200x200">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=EB+Garamond:400,500">
-  <link rel="stylesheet" href="{{ 'style.css' | asset_url }}" type="text/css" media="print" onload="this.media='all';onLoadStylesheet()">
-  <link rel="stylesheet" href="{{ 'slink.css' | asset_url }}" type="text/css" media="print" onload="this.media='all';onLoadStylesheet()">
+  <link rel="stylesheet" href="//cdn.shopify.com/s/files/1/0536/9544/7234/t/1/assets/style.css?ver{% capture today %}{{ 'today' | date: '%Y-%m-%d' }}{% endcapture %}">
+  <link rel="stylesheet" href="//cdn.shopify.com/s/files/1/0536/9544/7234/t/1/assets/slick.css?ver{% capture today %}{{ 'today' | date: '%Y-%m-%d' }}{% endcapture %}">
 
   {%- capture seo_title -%}
     {%- if request.page_type == 'search' and search.performed == true -%}
@@ -27,35 +27,14 @@
       &ndash; {{ shop.name }}
     {%- endunless -%}
   {%- endcapture -%}
-
   <title>{{ seo_title | strip }}</title>
-  <meta name="description" content="{{ page_description | escape }}">
-  <meta property="og:title" content="{{ seo_title | strip }}">
 
-  {%- assign og_type = 'website' -%}
-  {% if request.page_type == 'product' %}
-    {%- assign og_type = 'product' -%}
+  {%- if page_description -%}
+    <meta name="description" content="{{ page_description | escape }}">
+  {%- endif -%}
 
-  {% elsif request.page_type == 'article' %}
-    {%- assign og_type = 'article' -%}
+  {% include 'social-meta-tags' %}
 
-  {% elsif request.page_type == 'collection' %}
-    {%- assign og_type = 'product.group' -%}
-
-  {% elsif request.page_type == 'password' %}
-    {%- assign og_url = shop.url -%}
-  {% endif %}
-
-	<meta property="og:type" content="{{ og_type }}">
-	<meta property="og:url" content="{{ canonical_url }}">
-	<meta property="og:locale" content="ja_JP">
-	<meta property="og:description" content="{{ page_description | escape }}">
-	<meta property="og:site_name" content="{{ shop.name }}">
-  <meta property="og:image" content="{{ page_image | img_url }}" />
-	<meta name="twitter:card" content="summary">
-	<meta name="twitter:description" content="{{ page_description | escape }}">
-	<meta name="twitter:title" content="{{ seo_title | strip }}">
-	<meta name="twitter:image" content="{{ page_image | img_url }}">
   <meta name="robots" content="noindex">
   <meta name="robots" content="nofollow">
 	<script type="text/javascript" src="https://journal.komons-japan.com/wp-content/themes/komons-theme/js/layout.min.js?ver210126" charset="UTF-8"></script>

--- a/_shopify_files/edited/layout/theme.liquid
+++ b/_shopify_files/edited/layout/theme.liquid
@@ -8,7 +8,7 @@
 	<link rel="apple-touch-icon" href="https://journal.komons-japan.com/wp-content/themes/komons-theme/img/icon/icon.jpg" sizes="200x200">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=EB+Garamond:400,500">
   <link rel="stylesheet" href="//cdn.shopify.com/s/files/1/0536/9544/7234/t/1/assets/style.css?ver{% capture today %}{{ 'today' | date: '%Y-%m-%d' }}{% endcapture %}">
-  <link rel="stylesheet" href="//cdn.shopify.com/s/files/1/0536/9544/7234/t/1/assets/slick.css?ver{% capture today %}{{ 'today' | date: '%Y-%m-%d' }}{% endcapture %}">
+  <link rel="stylesheet" href="//cdn.shopify.com/s/files/1/0536/9544/7234/t/1/assets/slick.css">
 
   {%- capture seo_title -%}
     {%- if request.page_type == 'search' and search.performed == true -%}
@@ -37,8 +37,7 @@
 
   <meta name="robots" content="noindex">
   <meta name="robots" content="nofollow">
-	<script type="text/javascript" src="https://journal.komons-japan.com/wp-content/themes/komons-theme/js/layout.min.js?ver210126" charset="UTF-8"></script>
-	<script type="text/javascript" src="https://journal.komons-japan.com/wp-content/themes/komons-theme/js/instafeed.min.js"></script>
+	<script type="text/javascript" src="//cdn.shopify.com/s/files/1/0536/9544/7234/t/1/assets/layout.min.js?ver{% capture today %}{{ 'today' | date: '%Y-%m-%d' }}{% endcapture %}" charset="UTF-8"></script>
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-120930116-1"></script>
   <script>

--- a/_shopify_files/edited/snippets/social-meta-tags.liquid
+++ b/_shopify_files/edited/snippets/social-meta-tags.liquid
@@ -22,10 +22,12 @@
 <meta property="og:url" content="{{ og_url }}">
 <meta property="og:title" content="{{ og_title }}">
 <meta property="og:type" content="{{ og_type }}">
-<meta property="og:description" content="{{ og_description }}">
+<meta property="og:description" content="{{ og_description | escape }}">
+<meta property="og:locale" content="ja_JP">
 
 {%- if page_image -%}
   <meta property="og:image" content="http:{{ page_image | img_url: 'master' }}">
+  <meta name="twitter:image" content="{{ page_image | img_url }}">
   <meta property="og:image:secure_url" content="https:{{ page_image | img_url: 'master' }}">
   <meta property="og:image:width" content="{{ page_image.width }}">
   <meta property="og:image:height" content="{{ page_image.height }}">
@@ -40,5 +42,5 @@
   <meta name="twitter:site" content="{{ settings.social_twitter_link | split: 'twitter.com/' | last | prepend: '@' }}">
 {% endunless %}
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="{{ og_title }}">
-<meta name="twitter:description" content="{{ og_description }}">
+<meta name="twitter:title" content="{{ og_title | strip }}">
+<meta name="twitter:description" content="{{ og_description | escape }}">


### PR DESCRIPTION
- cssの読み込みをURLベタ書きに修正
- cssの読み込みにキャッシュ対策付与
- ogpの設定を`snippets/social-meta-tags.liquid`に分離
- `snippets/social-meta-tags.liquid`の修正